### PR TITLE
Fix: add fc_site_id in headers for nchp

### DIFF
--- a/comechi.py
+++ b/comechi.py
@@ -696,6 +696,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             'fc_use_device': 'null',
             'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36', }
 
+        channel_name = self.source.split('/')[-3]
+        fcid_request = requests.get(f'https://api.nicochannel.jp/fc/content_providers/channel_domain?current_site_domain=https:%2F%2Fnicochannel.jp%2F{channel_name}', headers=headers)
+        fcid = json.loads(fcid_request.text)['data']['content_providers']['id']
+        headers['fc_site_id'] = str(fcid)
+
         content_code = self.source.split('/')[-1]
         url_page = f'https://nfc-api.nicochannel.jp/fc/video_pages/{content_code}'
         url_token = f'https://nfc-api.nicochannel.jp/fc/video_pages/{content_code}/comments_user_token'


### PR DESCRIPTION
修复因 headers 中缺少 fc_site_id 导致无法从ニコニコチャンネルプラス下载弹幕的问题。  
今天下载 nchp 的弹幕时报错如下，参考 nicochannel_comment 的 [Issue #7](https://github.com/aorinngoDo/nicochannel_comment/issues/7) 发现是需要在 headers 中添加 fc_site_id。  

```
Traceback (most recent call last):
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 1576, in <module>
    ass = cmt.ass()
          ^^^^^^^^^
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 379, in ass
    ass_block_list = [script_info, default_style(), events_header, self.dialouges()]
                                                                   ^^^^^^^^^^^^^^^^
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 384, in dialouges
    self.build_dialogues()
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 394, in build_dialogues
    self.reclassify_cmt()
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 817, in reclassify_cmt
    self.get_data_raw()
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 624, in get_data_raw
    chat, operator_broadcasts_list = self.download_comment_nchp()
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Application\Tool\PyScript\Comechi-main\comechi.py", line 708, in download_comment_nchp
    group_id = video_pages['data']['video_page']['video_comment_setting']['comment_group_id']
               ~~~~~~~~~~~^^^^^^^^
KeyError: 'data'
```